### PR TITLE
Fixed license error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # ARG IMAGE=intersystemsdc/iris-community:2020.1.0.209.0-zpm
 ARG IMAGE=intersystemsdc/iris-community:2020.2.0.204.0-zpm
 # ARG IMAGE=store/intersystems/iris-community-arm64:2020.3.0.221.0
+#Replaced with below image to fix Error: Invalid Community Edition license
+ARG IMAGE=intersystemsdc/iris-community:2021.1.0.215.3-zpm
 FROM $IMAGE
 
 USER root


### PR DESCRIPTION
#Replaced with below image to fix Error: Invalid Community Edition license
ARG IMAGE=intersystemsdc/iris-community:2021.1.0.215.3-zpm
FROM $IMAGE